### PR TITLE
Set up Spring Data JPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,6 @@ mvn flyway:migrate
 ```bash
 mvn spring-boot:run -Dspring-boot.run.profiles=dev
 ```
+
+**Note: The `default` Spring profile is used by GitHub Actions workflows to make sure JPA starts up without requiring
+an external database, thus preventing build failures. GitHub Actions will pick up `default` automatically.**

--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ mvn clean install
 ### Starting application with Spring Boot Maven plugin
 
 ```bash
-mvn spring-boot:run -Dspring-boot.run.profiles=default
+mvn spring-boot:run -Dspring-boot.run.profiles=dev
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Run project locally
 mvn clean install
 ```
 
+### Build database schema with test data with Flyway Maven plugin
+
+```bash
+mvn flyway:migrate
+```
+
 ### Starting application with Spring Boot Maven plugin
 
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,8 @@
         <java.version>21</java.version>
 
         <!-- Maven plugin versions -->
-        <jacoco.version>0.8.13</jacoco.version>
+        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
+        <flyway-maven-plugin.version>10.15.0</flyway-maven-plugin.version>
 
         <!-- JaCoCo properties -->
         <jacoco.line-coverage>1.00</jacoco.line-coverage>
@@ -72,9 +73,13 @@
 
         <plugins>
             <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${jacoco.version}</version>
+                <version>${jacoco-maven-plugin.version}</version>
                 <configuration>
                     <excludes>
                         <exclude>com/github/jbence1994/erp/inventory/model/*</exclude>
@@ -137,8 +142,15 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
+                <groupId>org.flywaydb</groupId>
+                <artifactId>flyway-maven-plugin</artifactId>
+                <version>${flyway-maven-plugin.version}</version>
+                <configuration>
+                    <url>jdbc:mysql://localhost:3306/erp?createDatabaseIfNotExist=true</url>
+                    <user>root</user>
+                    <password/>
+                    <cleanDisabled>false</cleanDisabled>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>flyway-mysql</artifactId>
         </dependency>
         <dependency>
+            <artifactId>mysql-connector-j</artifactId>
+            <groupId>com.mysql</groupId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/github/jbence1994/erp/inventory/model/Product.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/model/Product.java
@@ -1,16 +1,39 @@
 package com.github.jbence1994.erp.inventory.model;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 import java.math.BigDecimal;
 
+@Entity
+@Table(name = "products")
 public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private String name;
+
     private String serialNumber;
+
     private BigDecimal price;
+
     private String unit;
+
     private String description;
+
+    @ManyToOne
+    @JoinColumn(name = "supplier_id")
     private Supplier supplier;
+
     private Integer onStock;
+
     private String photoFileName;
 
     public boolean hasPhoto() {

--- a/src/main/java/com/github/jbence1994/erp/inventory/model/Supplier.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/model/Supplier.java
@@ -1,8 +1,22 @@
 package com.github.jbence1994.erp.inventory.model;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "suppliers")
 public class Supplier {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private String name;
+
     private String phone;
+
     private String email;
 }

--- a/src/main/java/com/github/jbence1994/erp/inventory/repository/ProductRepository.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/repository/ProductRepository.java
@@ -1,0 +1,9 @@
+package com.github.jbence1994.erp.inventory.repository;
+
+import com.github.jbence1994.erp.inventory.model.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/com/github/jbence1994/erp/inventory/repository/SupplierRepository.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/repository/SupplierRepository.java
@@ -1,0 +1,9 @@
+package com.github.jbence1994.erp.inventory.repository;
+
+import com.github.jbence1994.erp.inventory.model.Supplier;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SupplierRepository extends JpaRepository<Supplier, Long> {
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/erp
+    username: root
+    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,3 +3,19 @@ spring:
     name: erp
   profiles:
     active: default
+  datasource:
+    url: jdbc:h2:mem:erp
+    username: root
+    password: 12345
+    driver-class-name: org.h2.Driver
+  h2:
+    console:
+      enabled: true
+  jpa:
+    generate-ddl: true
+    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: none
+    open-in-view: off
+  flyway:
+    enabled: false


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Setting up Spring Data JPA to read data from a local database and make existing data models JPA entities. Separating 'default' and 'dev' Spring profiles. Adding Flyway Maven plugin to generate database schema and populate it with test data and update README file to the corresponding changes. Adding an H2 in-memory database for the 'default' Spring profile for CI workflow.