### PR TITLE
Update README.md with the working command to start the application locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,10 @@ Run project locally
 Be sure to copy `.env.example` to `.env` and update it with your local database connection parameters before running the
 application.
 
-### Build application
+### Build application and database schema populating it with test data with Flyway Maven plugin
 
 ```bash
 mvn clean install
-```
-
-### Build database schema with test data with Flyway Maven plugin
-
-```bash
-mvn flyway:migrate
 ```
 
 ### Starting application with Spring Boot Maven plugin


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Updating README.md with the working command to start the application locally regarding building database with `mvn clean install` and not with `mvn flyway:migrate` due to the database secretd had been moved to the `.env` file.