### PR TITLE
Remove all annotations from interfaces

### DIFF
--- a/src/main/java/com/github/jbence1994/erp/common/util/FileUtils.java
+++ b/src/main/java/com/github/jbence1994/erp/common/util/FileUtils.java
@@ -1,11 +1,8 @@
 package com.github.jbence1994.erp.common.util;
 
-import org.springframework.stereotype.Component;
-
 import java.io.IOException;
 import java.io.InputStream;
 
-@Component
 public interface FileUtils {
     void store(String path, String fileName, InputStream stream) throws IOException;
 

--- a/src/main/java/com/github/jbence1994/erp/identity/repository/UserProfileRepository.java
+++ b/src/main/java/com/github/jbence1994/erp/identity/repository/UserProfileRepository.java
@@ -2,8 +2,6 @@ package com.github.jbence1994.erp.identity.repository;
 
 import com.github.jbence1994.erp.identity.model.UserProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
 }

--- a/src/main/java/com/github/jbence1994/erp/inventory/repository/ProductRepository.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/repository/ProductRepository.java
@@ -2,8 +2,6 @@ package com.github.jbence1994.erp.inventory.repository;
 
 import com.github.jbence1994.erp.inventory.model.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 }

--- a/src/main/java/com/github/jbence1994/erp/inventory/repository/SupplierRepository.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/repository/SupplierRepository.java
@@ -2,8 +2,6 @@ package com.github.jbence1994.erp.inventory.repository;
 
 import com.github.jbence1994.erp.inventory.model.Supplier;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface SupplierRepository extends JpaRepository<Supplier, Long> {
 }


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Removing `@Component` annotation from `FileUtils` interface. Removing `@Repository` annotation from all repository interfaces, details: https://docs.spring.io/spring-data/jpa/reference/repositories/definition.html