### PR TITLE
Apply the Template Method design pattern for photo services not to duplicate any photo-related code

### DIFF
--- a/src/main/java/com/github/jbence1994/erp/common/dto/CreatePhotoDto.java
+++ b/src/main/java/com/github/jbence1994/erp/common/dto/CreatePhotoDto.java
@@ -23,6 +23,8 @@ public abstract class CreatePhotoDto {
 
     private byte[] inputStreamBytes;
 
+    public abstract Long getEntityId();
+
     public InputStream getInputStream() {
         return new ByteArrayInputStream(inputStreamBytes);
     }

--- a/src/main/java/com/github/jbence1994/erp/common/model/PhotoEntity.java
+++ b/src/main/java/com/github/jbence1994/erp/common/model/PhotoEntity.java
@@ -1,0 +1,11 @@
+package com.github.jbence1994.erp.common.model;
+
+public interface PhotoEntity {
+    boolean hasPhoto();
+
+    String getPhotoFileName();
+
+    void setPhotoFileName(String fileName);
+
+    String getPhotoFileExtension();
+}

--- a/src/main/java/com/github/jbence1994/erp/common/service/PhotoService.java
+++ b/src/main/java/com/github/jbence1994/erp/common/service/PhotoService.java
@@ -10,19 +10,19 @@ import lombok.RequiredArgsConstructor;
 import java.io.IOException;
 
 @RequiredArgsConstructor
-public abstract class PhotoService<CreateDto extends CreatePhotoDto, Dto extends PhotoDto, Entity extends PhotoEntity> {
+public abstract class PhotoService<C extends CreatePhotoDto, D extends PhotoDto, E extends PhotoEntity> {
     protected final FileUtils fileUtils;
     protected final FileValidator fileValidator;
 
     protected String photoUploadDirectoryPath;
 
-    protected abstract Entity getEntity(Long id);
+    protected abstract E getEntity(Long id);
 
-    protected abstract void updateEntity(Entity entity);
+    protected abstract void updateEntity(E entity);
 
-    protected abstract String createFileName(CreateDto createDto);
+    protected abstract String createFileName(C createPhotoDto);
 
-    protected abstract Dto toDto(Long id, byte[] photoBytes, String extension);
+    protected abstract D dto(Long id, byte[] photoBytes, String extension);
 
     protected abstract RuntimeException alreadyHasPhotoUploadedException(Long id);
 
@@ -33,11 +33,11 @@ public abstract class PhotoService<CreateDto extends CreatePhotoDto, Dto extends
     protected abstract RuntimeException photoNotFoundException(Long id);
 
     public String uploadPhoto(CreatePhotoDto photoDto) {
-        var createDto = (CreateDto) photoDto;
-        var entityId = createDto.getEntityId();
+        var createPhotoDto = (C) photoDto;
+        var entityId = createPhotoDto.getEntityId();
 
         try {
-            fileValidator.validate(createDto);
+            fileValidator.validate(createPhotoDto);
 
             var entity = getEntity(entityId);
 
@@ -45,11 +45,11 @@ public abstract class PhotoService<CreateDto extends CreatePhotoDto, Dto extends
                 throw alreadyHasPhotoUploadedException(entityId);
             }
 
-            String fileName = createFileName(createDto);
+            String fileName = createFileName(createPhotoDto);
             fileUtils.store(
                     photoUploadDirectoryPath,
                     fileName,
-                    createDto.getInputStream()
+                    createPhotoDto.getInputStream()
             );
 
             entity.setPhotoFileName(fileName);
@@ -61,7 +61,7 @@ public abstract class PhotoService<CreateDto extends CreatePhotoDto, Dto extends
         }
     }
 
-    public Dto getPhoto(Long id) {
+    public D getPhoto(Long id) {
         try {
             var entity = getEntity(id);
 
@@ -74,7 +74,7 @@ public abstract class PhotoService<CreateDto extends CreatePhotoDto, Dto extends
                     entity.getPhotoFileName()
             );
 
-            return toDto(id, photoBytes, entity.getPhotoFileExtension());
+            return dto(id, photoBytes, entity.getPhotoFileExtension());
         } catch (IOException e) {
             throw photoDownloadException(id);
         }

--- a/src/main/java/com/github/jbence1994/erp/common/service/PhotoService.java
+++ b/src/main/java/com/github/jbence1994/erp/common/service/PhotoService.java
@@ -2,9 +2,81 @@ package com.github.jbence1994.erp.common.service;
 
 import com.github.jbence1994.erp.common.dto.CreatePhotoDto;
 import com.github.jbence1994.erp.common.dto.PhotoDto;
+import com.github.jbence1994.erp.common.model.PhotoEntity;
+import com.github.jbence1994.erp.common.util.FileUtils;
+import com.github.jbence1994.erp.common.validation.FileValidator;
+import lombok.RequiredArgsConstructor;
 
-public interface PhotoService {
-    String uploadPhoto(CreatePhotoDto photo);
+import java.io.IOException;
 
-    PhotoDto getPhoto(Long id);
+@RequiredArgsConstructor
+public abstract class PhotoService<CreateDto extends CreatePhotoDto, Dto extends PhotoDto, Entity extends PhotoEntity> {
+    protected final FileUtils fileUtils;
+    protected final FileValidator fileValidator;
+
+    protected String photoUploadDirectoryPath;
+
+    protected abstract Entity getEntity(Long id);
+
+    protected abstract void updateEntity(Entity entity);
+
+    protected abstract String createFileName(CreateDto createDto);
+
+    protected abstract Dto toDto(Long id, byte[] photoBytes, String extension);
+
+    protected abstract RuntimeException alreadyHasPhotoUploadedException(Long id);
+
+    protected abstract RuntimeException photoUploadException(Long id);
+
+    protected abstract RuntimeException photoDownloadException(Long id);
+
+    protected abstract RuntimeException photoNotFoundException(Long id);
+
+    public String uploadPhoto(CreatePhotoDto photoDto) {
+        var createDto = (CreateDto) photoDto;
+        var entityId = createDto.getEntityId();
+
+        try {
+            fileValidator.validate(createDto);
+
+            var entity = getEntity(entityId);
+
+            if (entity.hasPhoto()) {
+                throw alreadyHasPhotoUploadedException(entityId);
+            }
+
+            String fileName = createFileName(createDto);
+            fileUtils.store(
+                    photoUploadDirectoryPath,
+                    fileName,
+                    createDto.getInputStream()
+            );
+
+            entity.setPhotoFileName(fileName);
+            updateEntity(entity);
+
+            return fileName;
+        } catch (IOException e) {
+            throw photoUploadException(entityId);
+        }
+    }
+
+    public Dto getPhoto(Long id) {
+        try {
+            var entity = getEntity(id);
+
+            if (!entity.hasPhoto()) {
+                throw photoNotFoundException(id);
+            }
+
+            byte[] photoBytes = fileUtils.read(
+                    photoUploadDirectoryPath,
+                    entity.getPhotoFileName()
+            );
+
+            return toDto(id, photoBytes, entity.getPhotoFileExtension());
+        } catch (IOException e) {
+            throw photoDownloadException(id);
+        }
+    }
 }

--- a/src/main/java/com/github/jbence1994/erp/identity/dto/CreateUserProfilePhotoDto.java
+++ b/src/main/java/com/github/jbence1994/erp/identity/dto/CreateUserProfilePhotoDto.java
@@ -1,9 +1,7 @@
 package com.github.jbence1994.erp.identity.dto;
 
 import com.github.jbence1994.erp.common.dto.CreatePhotoDto;
-import lombok.Getter;
 
-@Getter
 public class CreateUserProfilePhotoDto extends CreatePhotoDto {
     private final Long userProfileId;
 
@@ -17,5 +15,10 @@ public class CreateUserProfilePhotoDto extends CreatePhotoDto {
     ) {
         super(isEmpty, originalFilename, size, contentType, inputStreamBytes);
         this.userProfileId = userProfileId;
+    }
+
+    @Override
+    public Long getEntityId() {
+        return userProfileId;
     }
 }

--- a/src/main/java/com/github/jbence1994/erp/identity/model/UserProfile.java
+++ b/src/main/java/com/github/jbence1994/erp/identity/model/UserProfile.java
@@ -1,5 +1,6 @@
 package com.github.jbence1994.erp.identity.model;
 
+import com.github.jbence1994.erp.common.model.PhotoEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -15,7 +16,7 @@ import org.springframework.util.StringUtils;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class UserProfile {
+public class UserProfile implements PhotoEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -32,10 +33,22 @@ public class UserProfile {
 
     private boolean isDeleted;
 
+    @Override
     public boolean hasPhoto() {
         return photoFileName != null;
     }
 
+    @Override
+    public String getPhotoFileName() {
+        return photoFileName;
+    }
+
+    @Override
+    public void setPhotoFileName(String photoFileName) {
+        this.photoFileName = photoFileName;
+    }
+
+    @Override
     public String getPhotoFileExtension() {
         return StringUtils.getFilenameExtension(photoFileName);
     }

--- a/src/main/java/com/github/jbence1994/erp/identity/service/UserProfilePhotoService.java
+++ b/src/main/java/com/github/jbence1994/erp/identity/service/UserProfilePhotoService.java
@@ -50,21 +50,21 @@ public class UserProfilePhotoService extends PhotoService<CreateUserProfilePhoto
 
     @Override
     protected RuntimeException alreadyHasPhotoUploadedException(Long id) {
-        throw new UserProfileAlreadyHasPhotoUploadedException(id);
+        return new UserProfileAlreadyHasPhotoUploadedException(id);
     }
 
     @Override
     protected RuntimeException photoUploadException(Long id) {
-        throw new UserProfilePhotoUploadException(id);
+        return new UserProfilePhotoUploadException(id);
     }
 
     @Override
     protected RuntimeException photoDownloadException(Long id) {
-        throw new UserProfilePhotoDownloadException(id);
+        return new UserProfilePhotoDownloadException(id);
     }
 
     @Override
     protected RuntimeException photoNotFoundException(Long id) {
-        throw new UserProfilePhotoNotFoundException(id);
+        return new UserProfilePhotoNotFoundException(id);
     }
 }

--- a/src/main/java/com/github/jbence1994/erp/identity/service/UserProfilePhotoService.java
+++ b/src/main/java/com/github/jbence1994/erp/identity/service/UserProfilePhotoService.java
@@ -44,7 +44,7 @@ public class UserProfilePhotoService extends PhotoService<CreateUserProfilePhoto
     }
 
     @Override
-    protected UserProfilePhotoDto toDto(Long id, byte[] photoBytes, String extension) {
+    protected UserProfilePhotoDto dto(Long id, byte[] photoBytes, String extension) {
         return new UserProfilePhotoDto(id, photoBytes, extension);
     }
 

--- a/src/main/java/com/github/jbence1994/erp/inventory/dto/CreateProductPhotoDto.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/dto/CreateProductPhotoDto.java
@@ -1,9 +1,7 @@
 package com.github.jbence1994.erp.inventory.dto;
 
 import com.github.jbence1994.erp.common.dto.CreatePhotoDto;
-import lombok.Getter;
 
-@Getter
 public class CreateProductPhotoDto extends CreatePhotoDto {
     private final Long productId;
 
@@ -17,5 +15,10 @@ public class CreateProductPhotoDto extends CreatePhotoDto {
     ) {
         super(isEmpty, originalFilename, size, contentType, inputStreamBytes);
         this.productId = productId;
+    }
+
+    @Override
+    public Long getEntityId() {
+        return productId;
     }
 }

--- a/src/main/java/com/github/jbence1994/erp/inventory/model/Product.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/model/Product.java
@@ -1,5 +1,6 @@
 package com.github.jbence1994.erp.inventory.model;
 
+import com.github.jbence1994.erp.common.model.PhotoEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -19,7 +20,7 @@ import java.math.BigDecimal;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class Product {
+public class Product implements PhotoEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -42,10 +43,22 @@ public class Product {
 
     private String photoFileName;
 
+    @Override
     public boolean hasPhoto() {
         return photoFileName != null;
     }
 
+    @Override
+    public String getPhotoFileName() {
+        return photoFileName;
+    }
+
+    @Override
+    public void setPhotoFileName(String photoFileName) {
+        this.photoFileName = photoFileName;
+    }
+
+    @Override
     public String getPhotoFileExtension() {
         return StringUtils.getFilenameExtension(photoFileName);
     }

--- a/src/main/java/com/github/jbence1994/erp/inventory/service/ProductPhotoService.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/service/ProductPhotoService.java
@@ -50,21 +50,21 @@ public class ProductPhotoService extends PhotoService<CreateProductPhotoDto, Pro
 
     @Override
     protected RuntimeException alreadyHasPhotoUploadedException(Long id) {
-        throw new ProductAlreadyHasPhotoUploadedException(id);
+        return new ProductAlreadyHasPhotoUploadedException(id);
     }
 
     @Override
     protected RuntimeException photoUploadException(Long id) {
-        throw new ProductPhotoUploadException(id);
+        return new ProductPhotoUploadException(id);
     }
 
     @Override
     protected RuntimeException photoDownloadException(Long id) {
-        throw new ProductPhotoDownloadException(id);
+        return new ProductPhotoDownloadException(id);
     }
 
     @Override
     protected RuntimeException photoNotFoundException(Long id) {
-        throw new ProductPhotoNotFoundException(id);
+        return new ProductPhotoNotFoundException(id);
     }
 }

--- a/src/main/java/com/github/jbence1994/erp/inventory/service/ProductPhotoService.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/service/ProductPhotoService.java
@@ -1,7 +1,5 @@
 package com.github.jbence1994.erp.inventory.service;
 
-import com.github.jbence1994.erp.common.dto.CreatePhotoDto;
-import com.github.jbence1994.erp.common.dto.PhotoDto;
 import com.github.jbence1994.erp.common.service.PhotoService;
 import com.github.jbence1994.erp.common.util.FileUtils;
 import com.github.jbence1994.erp.common.validation.FileValidator;
@@ -11,67 +9,62 @@ import com.github.jbence1994.erp.inventory.exception.ProductAlreadyHasPhotoUploa
 import com.github.jbence1994.erp.inventory.exception.ProductPhotoDownloadException;
 import com.github.jbence1994.erp.inventory.exception.ProductPhotoNotFoundException;
 import com.github.jbence1994.erp.inventory.exception.ProductPhotoUploadException;
-import lombok.RequiredArgsConstructor;
+import com.github.jbence1994.erp.inventory.model.Product;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-
 @Service
-@RequiredArgsConstructor
-public class ProductPhotoService implements PhotoService {
+public class ProductPhotoService extends PhotoService<CreateProductPhotoDto, ProductPhotoDto, Product> {
     private final ProductService productService;
-    private final FileUtils fileUtils;
-    private final FileValidator fileValidator;
 
-    @Value("${erp.photo-upload-directory-path.products}")
-    private String photoUploadDirectoryPath;
-
-    @Override
-    public String uploadPhoto(CreatePhotoDto photo) {
-        var productPhoto = (CreateProductPhotoDto) photo;
-
-        try {
-            fileValidator.validate(productPhoto);
-
-            var product = productService.getProduct(productPhoto.getProductId());
-
-            if (product.hasPhoto()) {
-                throw new ProductAlreadyHasPhotoUploadedException(productPhoto.getProductId());
-            }
-
-            var photoName = photo.createFileName();
-            fileUtils.store(
-                    photoUploadDirectoryPath,
-                    photoName,
-                    productPhoto.getInputStream()
-            );
-            product.setPhotoFileName(photoName);
-            productService.updateProduct(product);
-
-            return product.getPhotoFileName();
-        } catch (IOException exception) {
-            throw new ProductPhotoUploadException(productPhoto.getProductId());
-        }
+    public ProductPhotoService(
+            @Value("${erp.photo-upload-directory-path.products}") final String photoUploadDirectoryPath,
+            final ProductService productService,
+            final FileUtils fileUtils,
+            final FileValidator fileValidator
+    ) {
+        super(fileUtils, fileValidator);
+        this.productService = productService;
+        this.photoUploadDirectoryPath = photoUploadDirectoryPath;
     }
 
     @Override
-    public PhotoDto getPhoto(Long id) {
-        try {
-            var product = productService.getProduct(id);
+    protected Product getEntity(Long id) {
+        return productService.getProduct(id);
+    }
 
-            if (!product.hasPhoto()) {
-                throw new ProductPhotoNotFoundException(id);
-            }
+    @Override
+    protected void updateEntity(Product product) {
+        productService.updateProduct(product);
+    }
 
-            var photoBytes = fileUtils.read(
-                    photoUploadDirectoryPath,
-                    product.getPhotoFileName()
-            );
+    @Override
+    protected String createFileName(CreateProductPhotoDto createProductPhotoDto) {
+        return createProductPhotoDto.createFileName();
+    }
 
-            return new ProductPhotoDto(id, photoBytes, product.getPhotoFileExtension());
-        } catch (IOException exception) {
-            throw new ProductPhotoDownloadException(id);
-        }
+    @Override
+    protected ProductPhotoDto toDto(Long id, byte[] photoBytes, String extension) {
+        return new ProductPhotoDto(id, photoBytes, extension);
+    }
+
+    @Override
+    protected RuntimeException alreadyHasPhotoUploadedException(Long id) {
+        throw new ProductAlreadyHasPhotoUploadedException(id);
+    }
+
+    @Override
+    protected RuntimeException photoUploadException(Long id) {
+        throw new ProductPhotoUploadException(id);
+    }
+
+    @Override
+    protected RuntimeException photoDownloadException(Long id) {
+        throw new ProductPhotoDownloadException(id);
+    }
+
+    @Override
+    protected RuntimeException photoNotFoundException(Long id) {
+        throw new ProductPhotoNotFoundException(id);
     }
 }

--- a/src/main/java/com/github/jbence1994/erp/inventory/service/ProductPhotoService.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/service/ProductPhotoService.java
@@ -44,7 +44,7 @@ public class ProductPhotoService extends PhotoService<CreateProductPhotoDto, Pro
     }
 
     @Override
-    protected ProductPhotoDto toDto(Long id, byte[] photoBytes, String extension) {
+    protected ProductPhotoDto dto(Long id, byte[] photoBytes, String extension) {
         return new ProductPhotoDto(id, photoBytes, extension);
     }
 

--- a/src/test/java/com/github/jbence1994/erp/identity/mapper/MultipartFileToCreateUserProfilePhotoDtoMapperTests.java
+++ b/src/test/java/com/github/jbence1994/erp/identity/mapper/MultipartFileToCreateUserProfilePhotoDtoMapperTests.java
@@ -25,7 +25,7 @@ class MultipartFileToCreateUserProfilePhotoDtoMapperTests {
     public void toDtoTest_HappyPath() throws IOException {
         var result = toProfilePhotoDtoMapper.toDto(1L, multipartFile());
 
-        assertEquals(1L, result.getUserProfileId());
+        assertEquals(1L, result.getEntityId());
         assertEquals(multipartFile().isEmpty(), result.isEmpty());
         assertEquals(multipartFile().getOriginalFilename(), result.getOriginalFilename());
         assertEquals(multipartFile().getSize(), result.getSize());

--- a/src/test/java/com/github/jbence1994/erp/inventory/mapper/MultipartFileToCreateProductPhotoDtoMapperTests.java
+++ b/src/test/java/com/github/jbence1994/erp/inventory/mapper/MultipartFileToCreateProductPhotoDtoMapperTests.java
@@ -25,7 +25,7 @@ class MultipartFileToCreateProductPhotoDtoMapperTests {
     public void toDtoTest_HappyPath() throws IOException {
         var result = toProductPhotoDtoMapper.toDto(1L, multipartFile());
 
-        assertEquals(1L, result.getProductId());
+        assertEquals(1L, result.getEntityId());
         assertEquals(multipartFile().isEmpty(), result.isEmpty());
         assertEquals(multipartFile().getOriginalFilename(), result.getOriginalFilename());
         assertEquals(multipartFile().getSize(), result.getSize());

--- a/src/test/java/com/github/jbence1994/erp/inventory/service/ProductPhotoServiceTests.java
+++ b/src/test/java/com/github/jbence1994/erp/inventory/service/ProductPhotoServiceTests.java
@@ -95,7 +95,7 @@ class ProductPhotoServiceTests {
     }
 
     @Test
-    public void getPhotoTest_UnhappyPath_UserProfileHasNoPhoto() {
+    public void getPhotoTest_UnhappyPath_ProductHasNoPhoto() {
         when(productService.getProduct(any())).thenReturn(product1());
 
         assertThrows(


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Applying the Template Method design pattern for an abstract, generic PhotoService class, not to duplicate any photo-related code twice for Product and UserProfile photo service implementations.