### PR TITLE
Refactor PhotoEntity

### DIFF
--- a/src/main/java/com/github/jbence1994/erp/common/model/PhotoEntity.java
+++ b/src/main/java/com/github/jbence1994/erp/common/model/PhotoEntity.java
@@ -1,11 +1,17 @@
 package com.github.jbence1994.erp.common.model;
 
-public interface PhotoEntity {
-    boolean hasPhoto();
+import org.springframework.util.StringUtils;
 
-    String getPhotoFileName();
+public abstract class PhotoEntity {
+    public abstract String getPhotoFileName();
 
-    void setPhotoFileName(String fileName);
+    public abstract void setPhotoFileName(String fileName);
 
-    String getPhotoFileExtension();
+    public boolean hasPhoto() {
+        return getPhotoFileName() != null;
+    }
+
+    public String getPhotoFileExtension() {
+        return StringUtils.getFilenameExtension(getPhotoFileName());
+    }
 }

--- a/src/main/java/com/github/jbence1994/erp/identity/controller/UserProfilePhotoController.java
+++ b/src/main/java/com/github/jbence1994/erp/identity/controller/UserProfilePhotoController.java
@@ -6,12 +6,14 @@ import com.github.jbence1994.erp.common.exception.InvalidFileExtensionException;
 import com.github.jbence1994.erp.common.mapper.MultipartFileToCreatePhotoDtoMapper;
 import com.github.jbence1994.erp.common.service.PhotoService;
 import com.github.jbence1994.erp.identity.dto.CreateUserProfilePhotoDto;
+import com.github.jbence1994.erp.identity.dto.UserProfilePhotoDto;
 import com.github.jbence1994.erp.identity.exception.UserProfileAlreadyHasPhotoUploadedException;
 import com.github.jbence1994.erp.identity.exception.UserProfileNotFoundException;
 import com.github.jbence1994.erp.identity.exception.UserProfilePhotoDownloadException;
 import com.github.jbence1994.erp.identity.exception.UserProfilePhotoNotFoundException;
 import com.github.jbence1994.erp.identity.exception.UserProfilePhotoUploadException;
-import org.springframework.beans.factory.annotation.Qualifier;
+import com.github.jbence1994.erp.identity.model.UserProfile;
+import lombok.AllArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -28,17 +30,10 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/userProfiles/{userProfileId}/photo")
 @CrossOrigin
+@AllArgsConstructor
 public class UserProfilePhotoController {
-    private final PhotoService photoService;
+    private final PhotoService<CreateUserProfilePhotoDto, UserProfilePhotoDto, UserProfile> photoService;
     private final MultipartFileToCreatePhotoDtoMapper<CreateUserProfilePhotoDto> toCreatePhotoDtoMapper;
-
-    public UserProfilePhotoController(
-            @Qualifier("userProfilePhotoService") PhotoService photoService,
-            MultipartFileToCreatePhotoDtoMapper<CreateUserProfilePhotoDto> toCreatePhotoDtoMapper
-    ) {
-        this.photoService = photoService;
-        this.toCreatePhotoDtoMapper = toCreatePhotoDtoMapper;
-    }
 
     @PostMapping
     public ResponseEntity<?> uploadUserProfilePhoto(

--- a/src/main/java/com/github/jbence1994/erp/identity/model/UserProfile.java
+++ b/src/main/java/com/github/jbence1994/erp/identity/model/UserProfile.java
@@ -7,16 +7,17 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.StringUtils;
+import lombok.Setter;
 
 @Entity
 @Table(name = "user_profiles")
-@Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class UserProfile implements PhotoEntity {
+@Getter
+@Setter
+public class UserProfile extends PhotoEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -34,11 +35,6 @@ public class UserProfile implements PhotoEntity {
     private boolean isDeleted;
 
     @Override
-    public boolean hasPhoto() {
-        return photoFileName != null;
-    }
-
-    @Override
     public String getPhotoFileName() {
         return photoFileName;
     }
@@ -46,10 +42,5 @@ public class UserProfile implements PhotoEntity {
     @Override
     public void setPhotoFileName(String photoFileName) {
         this.photoFileName = photoFileName;
-    }
-
-    @Override
-    public String getPhotoFileExtension() {
-        return StringUtils.getFilenameExtension(photoFileName);
     }
 }

--- a/src/main/java/com/github/jbence1994/erp/inventory/controller/ProductPhotoController.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/controller/ProductPhotoController.java
@@ -6,12 +6,14 @@ import com.github.jbence1994.erp.common.exception.InvalidFileExtensionException;
 import com.github.jbence1994.erp.common.mapper.MultipartFileToCreatePhotoDtoMapper;
 import com.github.jbence1994.erp.common.service.PhotoService;
 import com.github.jbence1994.erp.inventory.dto.CreateProductPhotoDto;
+import com.github.jbence1994.erp.inventory.dto.ProductPhotoDto;
 import com.github.jbence1994.erp.inventory.exception.ProductAlreadyHasPhotoUploadedException;
 import com.github.jbence1994.erp.inventory.exception.ProductNotFoundException;
 import com.github.jbence1994.erp.inventory.exception.ProductPhotoDownloadException;
 import com.github.jbence1994.erp.inventory.exception.ProductPhotoNotFoundException;
 import com.github.jbence1994.erp.inventory.exception.ProductPhotoUploadException;
-import org.springframework.beans.factory.annotation.Qualifier;
+import com.github.jbence1994.erp.inventory.model.Product;
+import lombok.AllArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -28,17 +30,10 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/products/{productId}/photo")
 @CrossOrigin
+@AllArgsConstructor
 public class ProductPhotoController {
-    private final PhotoService photoService;
+    private final PhotoService<CreateProductPhotoDto, ProductPhotoDto, Product> photoService;
     private final MultipartFileToCreatePhotoDtoMapper<CreateProductPhotoDto> toCreatePhotoDtoMapper;
-
-    public ProductPhotoController(
-            @Qualifier("productPhotoService") PhotoService photoService,
-            MultipartFileToCreatePhotoDtoMapper<CreateProductPhotoDto> toCreatePhotoDtoMapper
-    ) {
-        this.photoService = photoService;
-        this.toCreatePhotoDtoMapper = toCreatePhotoDtoMapper;
-    }
 
     @PostMapping
     public ResponseEntity<?> uploadProductPhoto(

--- a/src/main/java/com/github/jbence1994/erp/inventory/model/Product.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/model/Product.java
@@ -9,18 +9,19 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.StringUtils;
+import lombok.Setter;
 
 import java.math.BigDecimal;
 
 @Entity
 @Table(name = "products")
-@Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class Product implements PhotoEntity {
+@Getter
+@Setter
+public class Product extends PhotoEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -44,11 +45,6 @@ public class Product implements PhotoEntity {
     private String photoFileName;
 
     @Override
-    public boolean hasPhoto() {
-        return photoFileName != null;
-    }
-
-    @Override
     public String getPhotoFileName() {
         return photoFileName;
     }
@@ -56,10 +52,5 @@ public class Product implements PhotoEntity {
     @Override
     public void setPhotoFileName(String photoFileName) {
         this.photoFileName = photoFileName;
-    }
-
-    @Override
-    public String getPhotoFileExtension() {
-        return StringUtils.getFilenameExtension(photoFileName);
     }
 }

--- a/src/test/java/com/github/jbence1994/erp/identity/controller/UserProfilePhotoControllerTests.java
+++ b/src/test/java/com/github/jbence1994/erp/identity/controller/UserProfilePhotoControllerTests.java
@@ -4,13 +4,15 @@ import com.github.jbence1994.erp.common.dto.PhotoResponse;
 import com.github.jbence1994.erp.common.exception.EmptyFileException;
 import com.github.jbence1994.erp.common.exception.InvalidFileExtensionException;
 import com.github.jbence1994.erp.common.mapper.MultipartFileToCreatePhotoDtoMapper;
+import com.github.jbence1994.erp.common.service.PhotoService;
 import com.github.jbence1994.erp.identity.dto.CreateUserProfilePhotoDto;
+import com.github.jbence1994.erp.identity.dto.UserProfilePhotoDto;
 import com.github.jbence1994.erp.identity.exception.UserProfileAlreadyHasPhotoUploadedException;
 import com.github.jbence1994.erp.identity.exception.UserProfileNotFoundException;
 import com.github.jbence1994.erp.identity.exception.UserProfilePhotoDownloadException;
 import com.github.jbence1994.erp.identity.exception.UserProfilePhotoNotFoundException;
 import com.github.jbence1994.erp.identity.exception.UserProfilePhotoUploadException;
-import com.github.jbence1994.erp.identity.service.UserProfilePhotoService;
+import com.github.jbence1994.erp.identity.model.UserProfile;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -42,7 +44,7 @@ import static org.mockito.Mockito.when;
 class UserProfilePhotoControllerTests {
 
     @Mock
-    private UserProfilePhotoService userProfilePhotoService;
+    private PhotoService<CreateUserProfilePhotoDto, UserProfilePhotoDto, UserProfile> photoService;
 
     @Mock
     private MultipartFileToCreatePhotoDtoMapper<CreateUserProfilePhotoDto> toCreatePhotoDtoMapper;
@@ -52,7 +54,7 @@ class UserProfilePhotoControllerTests {
 
     @Test
     public void uploadUserProfilePhotoTest_HappyPath() {
-        when(userProfilePhotoService.uploadPhoto(any())).thenReturn(PHOTO_FILE_NAME);
+        when(photoService.uploadPhoto(any())).thenReturn(PHOTO_FILE_NAME);
 
         var result = userProfilePhotoController.uploadUserProfilePhoto(1L, multipartFile());
 
@@ -115,7 +117,7 @@ class UserProfilePhotoControllerTests {
             HttpStatus httpStatus,
             String exceptionMessage
     ) {
-        when(userProfilePhotoService.uploadPhoto(any())).thenThrow(exception);
+        when(photoService.uploadPhoto(any())).thenThrow(exception);
 
         var result = userProfilePhotoController.uploadUserProfilePhoto(userProfileId, multipartFile);
 
@@ -125,7 +127,7 @@ class UserProfilePhotoControllerTests {
 
     @Test
     public void getUserProfilePhotoTest_HappyPath() {
-        when(userProfilePhotoService.getPhoto(any())).thenReturn(userProfilePhotoDto());
+        when(photoService.getPhoto(any())).thenReturn(userProfilePhotoDto());
 
         var result = userProfilePhotoController.getUserProfilePhoto(1L);
 
@@ -171,7 +173,7 @@ class UserProfilePhotoControllerTests {
             String exceptionMessage
 
     ) {
-        when(userProfilePhotoService.getPhoto(any())).thenThrow(exception);
+        when(photoService.getPhoto(any())).thenThrow(exception);
 
         var result = userProfilePhotoController.getUserProfilePhoto(userProfileId);
 

--- a/src/test/java/com/github/jbence1994/erp/inventory/controller/ProductPhotoControllerTests.java
+++ b/src/test/java/com/github/jbence1994/erp/inventory/controller/ProductPhotoControllerTests.java
@@ -4,13 +4,15 @@ import com.github.jbence1994.erp.common.dto.PhotoResponse;
 import com.github.jbence1994.erp.common.exception.EmptyFileException;
 import com.github.jbence1994.erp.common.exception.InvalidFileExtensionException;
 import com.github.jbence1994.erp.common.mapper.MultipartFileToCreatePhotoDtoMapper;
+import com.github.jbence1994.erp.common.service.PhotoService;
 import com.github.jbence1994.erp.inventory.dto.CreateProductPhotoDto;
+import com.github.jbence1994.erp.inventory.dto.ProductPhotoDto;
 import com.github.jbence1994.erp.inventory.exception.ProductAlreadyHasPhotoUploadedException;
 import com.github.jbence1994.erp.inventory.exception.ProductNotFoundException;
 import com.github.jbence1994.erp.inventory.exception.ProductPhotoDownloadException;
 import com.github.jbence1994.erp.inventory.exception.ProductPhotoNotFoundException;
 import com.github.jbence1994.erp.inventory.exception.ProductPhotoUploadException;
-import com.github.jbence1994.erp.inventory.service.ProductPhotoService;
+import com.github.jbence1994.erp.inventory.model.Product;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -42,7 +44,7 @@ import static org.mockito.Mockito.when;
 class ProductPhotoControllerTests {
 
     @Mock
-    private ProductPhotoService productPhotoService;
+    private PhotoService<CreateProductPhotoDto, ProductPhotoDto, Product> photoService;
 
     @Mock
     private MultipartFileToCreatePhotoDtoMapper<CreateProductPhotoDto> toCreatePhotoDtoMapper;
@@ -52,7 +54,7 @@ class ProductPhotoControllerTests {
 
     @Test
     public void uploadProductPhotoTest_HappyPath() {
-        when(productPhotoService.uploadPhoto(any())).thenReturn(PHOTO_FILE_NAME);
+        when(photoService.uploadPhoto(any())).thenReturn(PHOTO_FILE_NAME);
 
         var result = productPhotoController.uploadProductPhoto(1L, multipartFile());
 
@@ -115,7 +117,7 @@ class ProductPhotoControllerTests {
             HttpStatus httpStatus,
             String exceptionMessage
     ) {
-        when(productPhotoService.uploadPhoto(any())).thenThrow(exception);
+        when(photoService.uploadPhoto(any())).thenThrow(exception);
 
         var result = productPhotoController.uploadProductPhoto(productId, multipartFile);
 
@@ -125,7 +127,7 @@ class ProductPhotoControllerTests {
 
     @Test
     public void getProductPhotoTest_HappyPath() {
-        when(productPhotoService.getPhoto(any())).thenReturn(productPhotoDto());
+        when(photoService.getPhoto(any())).thenReturn(productPhotoDto());
 
         var result = productPhotoController.getProductPhoto(1L);
 
@@ -170,7 +172,7 @@ class ProductPhotoControllerTests {
             HttpStatus httpStatus,
             String exceptionMessage
     ) {
-        when(productPhotoService.getPhoto(any())).thenThrow(exception);
+        when(photoService.getPhoto(any())).thenThrow(exception);
 
         var result = productPhotoController.getProductPhoto(productId);
 

--- a/src/test/java/com/github/jbence1994/erp/inventory/service/ProductServiceImplTests.java
+++ b/src/test/java/com/github/jbence1994/erp/inventory/service/ProductServiceImplTests.java
@@ -68,7 +68,18 @@ class ProductServiceImplTests {
 
         var result = productService.createProduct(product1());
 
-        assertEquals(product1(), result);
+        assertEquals(product1().getId(), result.getId());
+        assertEquals(product1().getName(), result.getName());
+        assertEquals(product1().getSerialNumber(), result.getSerialNumber());
+        assertEquals(product1().getPrice(), result.getPrice());
+        assertEquals(product1().getUnit(), result.getUnit());
+        assertEquals(product1().getDescription(), result.getDescription());
+        assertEquals(product1().getSupplier().getId(), result.getSupplier().getId());
+        assertEquals(product1().getSupplier().getName(), result.getSupplier().getName());
+        assertEquals(product1().getSupplier().getPhone(), result.getSupplier().getPhone());
+        assertEquals(product1().getSupplier().getEmail(), result.getSupplier().getEmail());
+        assertEquals(product1().getOnStock(), result.getOnStock());
+        assertEquals(product1().getPhotoFileName(), result.getPhotoFileName());
     }
 
     @Test


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Refactoring PhotoEntity interface to an abstract class to eliminate code duplications for several helper methods. Fixing photo services injections to the controllers with the generic interfaces.