### PR TITLE
Refactor CreatePhotoDto

### DIFF
--- a/src/main/java/com/github/jbence1994/erp/common/dto/CreatePhotoDto.java
+++ b/src/main/java/com/github/jbence1994/erp/common/dto/CreatePhotoDto.java
@@ -28,7 +28,7 @@ public abstract class CreatePhotoDto {
     }
 
     public String createFileName() {
-        return String.format("%s.%s", UUID.randomUUID(), StringUtils.getFilenameExtension(originalFilename));
+        return String.format("%s.%s", UUID.randomUUID(), getFileExtension());
     }
 
     public String getFileExtension() {

--- a/src/main/java/com/github/jbence1994/erp/common/dto/CreatePhotoDto.java
+++ b/src/main/java/com/github/jbence1994/erp/common/dto/CreatePhotoDto.java
@@ -2,7 +2,6 @@ package com.github.jbence1994.erp.common.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.experimental.Accessors;
 import org.springframework.util.StringUtils;
 
 import java.io.ByteArrayInputStream;
@@ -12,7 +11,6 @@ import java.util.UUID;
 @AllArgsConstructor
 @Getter
 public abstract class CreatePhotoDto {
-    @Accessors(fluent = true)
     private boolean isEmpty;
 
     private String originalFilename;


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Removing lombok's `@Accessor` annotation from `isEmpty` field. Using `getFileExtension()` function to avoid code duplication when creating a file name for a newly uploaded photo.