### PR TITLE
Limit setters for data models

### DIFF
--- a/src/main/java/com/github/jbence1994/erp/common/config/FileExtensionsConfig.java
+++ b/src/main/java/com/github/jbence1994/erp/common/config/FileExtensionsConfig.java
@@ -1,12 +1,14 @@
 package com.github.jbence1994.erp.common.config;
 
-import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
 
 @ConfigurationProperties(prefix = "erp.file-extensions-config")
-@Data
+@AllArgsConstructor
+@Getter
 public class FileExtensionsConfig {
     private List<String> allowedFileExtensions;
 }

--- a/src/main/java/com/github/jbence1994/erp/identity/model/UserProfile.java
+++ b/src/main/java/com/github/jbence1994/erp/identity/model/UserProfile.java
@@ -9,14 +9,12 @@ import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Table(name = "user_profiles")
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-@Setter
 public class UserProfile extends PhotoEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,5 +40,13 @@ public class UserProfile extends PhotoEntity {
     @Override
     public void setPhotoFileName(String photoFileName) {
         this.photoFileName = photoFileName;
+    }
+
+    public void updatePassword(String newPassword) {
+        password = newPassword;
+    }
+
+    public void deleteProfile() {
+        isDeleted = true;
     }
 }

--- a/src/main/java/com/github/jbence1994/erp/identity/service/UserProfileServiceImpl.java
+++ b/src/main/java/com/github/jbence1994/erp/identity/service/UserProfileServiceImpl.java
@@ -31,7 +31,7 @@ public class UserProfileServiceImpl implements UserProfileService {
             throw new UserProfileAlreadyExistException(userProfileId);
         }
 
-        userProfile.setPassword(passwordManager.encode(userProfile.getPassword()));
+        userProfile.updatePassword(passwordManager.encode(userProfile.getPassword()));
 
         return userProfileRepository.save(userProfile);
     }
@@ -52,7 +52,7 @@ public class UserProfileServiceImpl implements UserProfileService {
             throw new UserProfileCurrentPasswordAndPasswordNotMatchingException();
         }
 
-        userProfileToUpdate.setPassword(passwordManager.encode(userProfileNewPassword));
+        userProfileToUpdate.updatePassword(passwordManager.encode(userProfileNewPassword));
 
         userProfileRepository.save(userProfileToUpdate);
     }
@@ -61,7 +61,7 @@ public class UserProfileServiceImpl implements UserProfileService {
     public void deleteUserProfile(Long id) {
         var userProfileToDelete = getUserProfile(id);
 
-        userProfileToDelete.setDeleted(true);
+        userProfileToDelete.deleteProfile();
 
         userProfileRepository.save(userProfileToDelete);
     }

--- a/src/main/java/com/github/jbence1994/erp/inventory/model/Product.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/model/Product.java
@@ -12,7 +12,6 @@ import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.math.BigDecimal;
 
@@ -21,7 +20,6 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-@Setter
 public class Product extends PhotoEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/github/jbence1994/erp/inventory/model/Supplier.java
+++ b/src/main/java/com/github/jbence1994/erp/inventory/model/Supplier.java
@@ -7,13 +7,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "suppliers")
-@Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 public class Supplier {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/com/github/jbence1994/erp/inventory/service/SupplierServiceImplTests.java
+++ b/src/test/java/com/github/jbence1994/erp/inventory/service/SupplierServiceImplTests.java
@@ -29,7 +29,10 @@ class SupplierServiceImplTests {
 
         var result = supplierService.createSupplier(supplier1());
 
-        assertEquals(supplier1(), result);
+        assertEquals(supplier1().getId(), result.getId());
+        assertEquals(supplier1().getName(), result.getName());
+        assertEquals(supplier1().getPhone(), result.getPhone());
+        assertEquals(supplier1().getEmail(), result.getEmail());
     }
 
     @Test


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Limiting setters for data models, using `@AllArgsConstructor` and `@Getter` annotations instead. Reflecting with data model method names for actions (e.g.: `updatePassword` and `deleteProfile`.